### PR TITLE
fix: Use ES Module for pitchfinder dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
     <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.0.1/dist/chartjs-plugin-annotation.min.js"></script>
-    <script src="https://unpkg.com/pitchfinder@2.1.3/lib/pitchfinder.min.js"></script>
-    <script src="main.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+import * as Pitchfinder from 'https://esm.sh/pitchfinder@2.3.2';
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- DOM要素 ---
     const startButton = document.getElementById('startButton');


### PR DESCRIPTION
- I've replaced the CDN script tag in index.html with a module-type script for main.js.
- I've added an import statement in main.js to load pitchfinder from esm.sh.

This resolves the persistent MIME type errors by switching to a modern module loading approach and a more reliable CDN service for this specific package.